### PR TITLE
fix: use processor for `/confirm-email/`

### DIFF
--- a/ft-email-auth-provider/Cargo.lock
+++ b/ft-email-auth-provider/Cargo.lock
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "ft-sdk"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f973e022718800ac1be18f7f8a3b94d7cbebee1cddcb8ffd46f046f805574d"
+checksum = "38c7a08ee0dd3fa28fb57a36dea81a523a159c67eabc9ddc14ac049671d248f8"
 dependencies = [
  "anyhow",
  "bytes",

--- a/ft-email-auth-provider/Cargo.toml
+++ b/ft-email-auth-provider/Cargo.toml
@@ -26,6 +26,6 @@ cookie = "0.18"
 
 
 [dependencies.ft-sdk]
-version = "0.1.8"
+version = "0.1.9"
 #path = "../../ft-sdk/ft-sdk"
 features = ["sqlite-default", "auth-provider", "field-extractors"]

--- a/ft-email-auth-provider/src/handlers/confirm_email.rs
+++ b/ft-email-auth-provider/src/handlers/confirm_email.rs
@@ -1,11 +1,12 @@
-#[ft_sdk::form]
+#[ft_sdk::processor]
 pub fn confirm_email(
     mut conn: ft_sdk::Connection,
     ft_sdk::Query(code): ft_sdk::Query<"code">,
     ft_sdk::Query(email): ft_sdk::Query<"email">,
+    ft_sdk::Query(next): ft_sdk::Query<"email", Option<String>>,
     host: ft_sdk::Host,
     mountpoint: ft_sdk::Mountpoint,
-) -> ft_sdk::form::Result {
+) -> ft_sdk::processor::Result {
     if !validator::ValidateEmail::validate_email(&email) {
         return Err(ft_sdk::single_error("email", "Invalid email format.").into());
     }
@@ -70,7 +71,8 @@ pub fn confirm_email(
 
     ft_sdk::auth::provider::update_user(&mut conn, auth::PROVIDER_ID, &user_id, data, false)?;
 
-    ft_sdk::form::redirect("/")
+    let next = next.unwrap_or_else(|| "/".to_string());
+    ft_sdk::processor::temporary_redirect(next)
 }
 
 /// check if it has been 90 days since the verification code was sent. The threshold can be

--- a/ft-email-auth-provider/src/handlers/create_account.rs
+++ b/ft-email-auth-provider/src/handlers/create_account.rs
@@ -346,7 +346,6 @@ pub fn generate_key(length: usize) -> String {
     ft_sdk::Rng::generate_key(length)
 }
 
-/// TODO: get mount point of this wasm
 pub fn confirmation_link(
     key: &str,
     email: &str,


### PR DESCRIPTION
This route handler is supposed to run in browser where our json redirect response does not work. This handler is now using
`processor::temporary_redirect` which is introduced in ft_sdk 0.1.9