### PR TITLE
impl Passowrd reset (aka Forgot password)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "ft-sdk"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5368dcb253bb5a2ed436ed4f37388e6bf95eb52b2784a5e95c0562c104eb5f5"
+checksum = "11809ba14cbb36aff93217e4311d0d493ffaf7492f2e1a35e9b6df122e5e185f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "ft-sys"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74248326ff7b53d4bb302c525dd5b1dbbfe943f93565bba9344120df913cfa85"
+checksum = "ce513fc62480e6563af4245aea398281b70453aed3c88c37ebad8badfaacf9e2"
 dependencies = [
  "bytes",
  "chrono",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "ft-sys-shared"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc875753df442d763e524a286bebede9488131adc52c7dcf8f5ac38d7afc076"
+checksum = "a5b532b534b1d9ac90e67a134ff546747fc1754b52891603f100a565acd9a889"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,6 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 validator = "0.18"
 cookie = "0.18"
 # ft-sdk = { path = "../ft-sdk/ft-sdk", features = ["sqlite-default", "auth-provider", "field-extractors"] }
-ft-sdk = { version = "0.1", features = ["sqlite-default", "auth-provider", "field-extractors"] }
+ft-sdk = { version = "0.1.16", features = ["sqlite-default", "auth-provider", "field-extractors"] }
 regex = "1"
 common = { path = "common" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ argon2 = "0.5"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 validator = "0.18"
 cookie = "0.18"
-#ft-sdk = { version = "0.1.11", path = "../../ft-sdk/ft-sdk", features = ["sqlite-default", "auth-provider", "field-extractors"] }
-ft-sdk = { version = "0.1.14", features = ["sqlite-default", "auth-provider", "field-extractors"] }
+# ft-sdk = { path = "../ft-sdk/ft-sdk", features = ["sqlite-default", "auth-provider", "field-extractors"] }
+ft-sdk = { version = "0.1", features = ["sqlite-default", "auth-provider", "field-extractors"] }
 regex = "1"
 common = { path = "common" }

--- a/email-auth-provider/src/handlers/confirm_email.rs
+++ b/email-auth-provider/src/handlers/confirm_email.rs
@@ -30,13 +30,9 @@ pub fn confirm_email(
     }
 
     let sent_at = data
-        .custom
-        .as_object()
-        .expect("custom is a json object")
-        .get(email_auth::EMAIL_CONF_SENT_AT)
-        .expect("email_conf_sent_at should exists if the account was found")
-        .as_i64()
-        .expect("value must be an i64 datetime in nanoseconds");
+        .get_custom::<i64>(email_auth::EMAIL_CONF_SENT_AT)
+        .expect("email_conf_sent_at should exists if the account was found");
+
     let sent_at = chrono::DateTime::from_timestamp_nanos(sent_at);
 
     if key_expired(sent_at) {
@@ -49,7 +45,7 @@ pub fn confirm_email(
             &mut conn,
         )?;
 
-        let name = data.name.unwrap_or_else(|| "User".to_string());
+        let name = data.name.unwrap_or_else(|| email.clone());
 
         email_auth::handlers::resend_confirmation_email::send_confirmation_email(
             &mut conn, &email, &name, &conf_link,

--- a/email-auth-provider/src/handlers/confirm_email.rs
+++ b/email-auth-provider/src/handlers/confirm_email.rs
@@ -30,7 +30,7 @@ pub fn confirm_email(
     }
 
     let sent_at = data
-        .get_custom::<i64>(email_auth::EMAIL_CONF_SENT_AT)
+        .get_custom(email_auth::EMAIL_CONF_SENT_AT)
         .expect("email_conf_sent_at should exists if the account was found");
 
     let sent_at = chrono::DateTime::from_timestamp_nanos(sent_at);

--- a/email-auth-provider/src/handlers/forgot_password.rs
+++ b/email-auth-provider/src/handlers/forgot_password.rs
@@ -1,0 +1,186 @@
+#[ft_sdk::form]
+pub fn forgot_password(
+    mut conn: ft_sdk::Connection,
+    ft_sdk::Required(username_or_email): ft_sdk::Required<"username">,
+    ft_sdk::Optional(set_password_route): ft_sdk::Optional<"set-password-route">,
+    ft_sdk::Optional(next): ft_sdk::Optional<"next">,
+    host: ft_sdk::Host,
+    mountpoint: ft_sdk::Mountpoint,
+) -> ft_sdk::form::Result {
+    let (user_id, email, data) = get_user_data(&mut conn, username_or_email)?;
+    let user_name = data.name.clone().unwrap_or_else(|| email.clone());
+
+    let set_password_route = set_password_route.unwrap_or_else(|| "/set-password/".to_string());
+
+    let reset_link = generate_new_reset_key(
+        data,
+        &user_id,
+        &email,
+        set_password_route,
+        &host,
+        &mountpoint,
+        &mut conn,
+    )?;
+
+    send_reset_password_email(&mut conn, &email, &user_name, &reset_link)?;
+
+    ft_sdk::form::redirect(next.unwrap_or_else(|| "/".to_string()))
+}
+
+fn get_user_data(
+    conn: &mut ft_sdk::Connection,
+    username_or_email: String,
+) -> Result<(ft_sdk::UserId, String, ft_sdk::auth::ProviderData), ft_sdk::Error> {
+    if username_or_email.contains('@')
+        && !validator::ValidateEmail::validate_email(&username_or_email)
+    {
+        return Err(ft_sdk::single_error("username-or-email", "Incorrect email format.").into());
+    }
+
+    let (id, ud) =
+        match email_auth::utils::user_data_from_email_or_username(conn, username_or_email) {
+            Ok(v) => v,
+            Err(ft_sdk::auth::UserDataError::NoDataFound) => {
+                return Err(ft_sdk::single_error(
+                    "username-or-email",
+                    "No account is linked with the provided email",
+                )
+                .into());
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+    let email = match ud.first_email() {
+        Some(e) => e,
+        None => {
+            return Err(ft_sdk::single_error(
+                "username-or-email",
+                "No email found for the given user. Password reset email can't be sent.",
+            )
+            .into())
+        }
+    };
+
+    Ok((id, email, ud))
+}
+
+/// Generate a new password reset key for a given email and update the user table
+pub fn generate_new_reset_key(
+    mut data: ft_sdk::auth::ProviderData,
+    user_id: &ft_sdk::auth::UserId,
+    email: &str,
+    set_password_route: String,
+    host: &ft_sdk::Host,
+    mountpoint: &ft_sdk::Mountpoint,
+    conn: &mut ft_sdk::Connection,
+) -> Result<String, ft_sdk::Error> {
+    let key = ft_sdk::Rng::generate_key(64);
+
+    let reset_link = reset_link(&key, email, set_password_route, host, mountpoint);
+
+    ft_sdk::println!("Password reset link added {reset_link}");
+
+    // update user probably does not merge the data. Even if it does, I don't want to a construct a
+    // whole ProviderData just to insert some custom key values
+    data.custom.as_object_mut().unwrap().insert(
+        email_auth::PASSWORD_RESET_CODE_KEY.to_string(),
+        serde_json::Value::String(key),
+    );
+
+    data.custom.as_object_mut().unwrap().insert(
+        email_auth::PASSWORD_RESET_CODE_SENT_AT.to_string(),
+        serde_json::Value::String(ft_sdk::env::now().to_rfc3339()),
+    );
+
+    ft_sdk::auth::provider::update_user(
+        conn,
+        email_auth::PROVIDER_ID,
+        user_id,
+        data.clone(),
+        false,
+    )?;
+
+    Ok(reset_link)
+}
+
+pub fn send_reset_password_email(
+    conn: &mut ft_sdk::Connection,
+    email: &str,
+    name: &str,
+    link: &str,
+) -> Result<(), ft_sdk::Error> {
+    let (from_name, from_email) =
+        email_auth::handlers::create_account::email_from_address_from_env();
+
+    ft_sdk::println!("Found email sender: {from_name}, {from_email}");
+
+    if let Err(e) = ft_sdk::send_email(
+        conn,
+        (&from_name, &from_email),
+        vec![(name, email)],
+        "Reset password",
+        &password_reset_request_html_template(name, link),
+        &password_reset_request_text_template(name, link),
+        None,
+        None,
+        None,
+        "auth_reset_password_request",
+    ) {
+        ft_sdk::println!("auth.wasm: failed to queue email: {:?}", e);
+        return Err(e.into());
+    }
+
+    ft_sdk::println!("Email added to the queue");
+
+    Ok(())
+}
+
+fn password_reset_request_text_template(name: &str, link: &str) -> String {
+    format!(
+        r#"
+            <html>
+                <head>
+                    <title>Password reset request</title>
+                </head>
+                <body>
+                    <h1>Hi {name},</h1>
+                    <p>Click the link below to reset password of your account</p>
+                    <a href="{link}">Reset password</a>
+
+                    In case you can't click the link, copy and paste the following link in your browser:
+                    <br>
+                    <a href="{link}">{link}</a>
+                </body>
+            </html>
+            "#,
+    )
+}
+
+fn password_reset_request_html_template(name: &str, link: &str) -> String {
+    format!(
+        r#"
+            Hi {name},
+
+            Click the link below to reset password of your account:
+
+            {link}
+
+            In case you can't click the link, copy and paste it in your browser.
+            "#,
+    )
+}
+
+/// Link to reset password.
+/// `set_password_route`: E.g. `/set-password/`
+pub fn reset_link(
+    key: &str,
+    email: &str,
+    set_password_route: String,
+    ft_sdk::Host(host): &ft_sdk::Host,
+    ft_sdk::Mountpoint(mountpoint): &ft_sdk::Mountpoint,
+) -> String {
+    format!(
+        "https://{host}{mountpoint}{set_password_route}?code={key}&email={email}",
+        mountpoint = mountpoint.trim_end_matches('/'),
+    )
+}

--- a/email-auth-provider/src/handlers/forgot_password.rs
+++ b/email-auth-provider/src/handlers/forgot_password.rs
@@ -176,5 +176,5 @@ pub fn reset_link(
 ) -> String {
     assert!(set_password_route.starts_with('/'));
     assert!(set_password_route.ends_with('/'));
-    format!("https://{host}{set_password_route}?code={key}&email={email}?spr={set_password_route}",)
+    format!("https://{host}{set_password_route}?code={key}&email={email}&spr={set_password_route}",)
 }

--- a/email-auth-provider/src/handlers/forgot_password.rs
+++ b/email-auth-provider/src/handlers/forgot_password.rs
@@ -83,9 +83,13 @@ pub fn generate_new_reset_key(
         serde_json::Value::String(key),
     );
 
+    let now = ft_sdk::env::now()
+        .timestamp_nanos_opt()
+        .expect("unexpected out of range datetime");
+
     data.custom.as_object_mut().unwrap().insert(
         email_auth::PASSWORD_RESET_CODE_SENT_AT.to_string(),
-        serde_json::Value::String(ft_sdk::env::now().to_rfc3339()),
+        serde_json::Value::Number(now.into()),
     );
 
     ft_sdk::auth::provider::update_user(

--- a/email-auth-provider/src/handlers/forgot_password.rs
+++ b/email-auth-provider/src/handlers/forgot_password.rs
@@ -180,7 +180,7 @@ pub fn reset_link(
     ft_sdk::Mountpoint(mountpoint): &ft_sdk::Mountpoint,
 ) -> String {
     format!(
-        "https://{host}{mountpoint}{set_password_route}?code={key}&email={email}",
+        "https://{host}{mountpoint}{set_password_route}?code={key}&email={email}?spr={set_password_route}",
         mountpoint = mountpoint.trim_end_matches('/'),
     )
 }

--- a/email-auth-provider/src/handlers/forgot_password.rs
+++ b/email-auth-provider/src/handlers/forgot_password.rs
@@ -24,7 +24,12 @@ pub fn forgot_password(
 
     send_reset_password_email(&mut conn, &email, &user_name, &reset_link)?;
 
-    ft_sdk::form::redirect(next.unwrap_or_else(|| "/".to_string()))
+    let next = format!(
+        "{}?email={}",
+        next.unwrap_or_else(|| "/".to_string()),
+        email
+    );
+    ft_sdk::form::redirect(next)
 }
 
 fn get_user_data(

--- a/email-auth-provider/src/handlers/forgot_password.rs
+++ b/email-auth-provider/src/handlers/forgot_password.rs
@@ -47,7 +47,7 @@ fn get_user_data(
             Ok(v) => v,
             Err(ft_sdk::auth::UserDataError::NoDataFound) => {
                 return Err(ft_sdk::single_error(
-                    "username-or-email",
+                    "username",
                     "No account is linked with the provided email",
                 )
                 .into());
@@ -59,7 +59,7 @@ fn get_user_data(
         Some(e) => e,
         None => {
             return Err(ft_sdk::single_error(
-                "username-or-email",
+                "username",
                 "No email found for the given user. Password reset email can't be sent.",
             )
             .into())

--- a/email-auth-provider/src/handlers/forgot_password.rs
+++ b/email-auth-provider/src/handlers/forgot_password.rs
@@ -1,7 +1,7 @@
 #[ft_sdk::form]
 pub fn forgot_password(
     mut conn: ft_sdk::Connection,
-    ft_sdk::Required(username_or_email): ft_sdk::Required<"username">,
+    ft_sdk::Required(username_or_email): ft_sdk::Required<"username-or-email">,
     ft_sdk::Optional(set_password_route): ft_sdk::Optional<"set-password-route">,
     ft_sdk::Optional(next): ft_sdk::Optional<"next">,
     host: ft_sdk::Host,
@@ -31,7 +31,7 @@ fn get_user_data(
     if username_or_email.contains('@')
         && !validator::ValidateEmail::validate_email(&username_or_email)
     {
-        return Err(ft_sdk::single_error("username", "Incorrect email format.").into());
+        return Err(ft_sdk::single_error("username-or-email", "Incorrect email format.").into());
     }
 
     let (id, ud) =
@@ -39,7 +39,7 @@ fn get_user_data(
             Ok(v) => v,
             Err(ft_sdk::auth::UserDataError::NoDataFound) => {
                 return Err(ft_sdk::single_error(
-                    "username",
+                    "username-or-email",
                     "No account is linked with the provided email",
                 )
                 .into());
@@ -51,7 +51,7 @@ fn get_user_data(
         Some(e) => e,
         None => {
             return Err(ft_sdk::single_error(
-                "username",
+                "username-or-email",
                 "No email found for the given user. Password reset email can't be sent.",
             )
             .into())

--- a/email-auth-provider/src/handlers/mod.rs
+++ b/email-auth-provider/src/handlers/mod.rs
@@ -3,3 +3,5 @@ pub mod create_account;
 pub mod login;
 pub mod resend_confirmation_email;
 pub mod user_data_by_code;
+pub mod forgot_password;
+pub(crate) mod utils;

--- a/email-auth-provider/src/handlers/mod.rs
+++ b/email-auth-provider/src/handlers/mod.rs
@@ -1,7 +1,8 @@
 pub mod confirm_email;
 pub mod create_account;
+pub mod forgot_password;
 pub mod login;
 pub mod resend_confirmation_email;
+pub mod set_password;
 pub mod user_data_by_code;
-pub mod forgot_password;
 pub(crate) mod utils;

--- a/email-auth-provider/src/handlers/set_password.rs
+++ b/email-auth-provider/src/handlers/set_password.rs
@@ -1,0 +1,129 @@
+#[ft_sdk::processor]
+pub fn set_password(
+    mut conn: ft_sdk::Connection,
+    ft_sdk::Required(new_password): ft_sdk::Required<"new-password">,
+    ft_sdk::Required(new_password2): ft_sdk::Required<"new-password2">,
+    ft_sdk::Query(code): ft_sdk::Query<"code">,
+    ft_sdk::Query(spr): ft_sdk::Query<"spr">,
+    ft_sdk::Query(email): ft_sdk::Query<"email">,
+    ft_sdk::Query(next): ft_sdk::Query<"next", Option<String>>,
+    host: ft_sdk::Host,
+    mountpoint: ft_sdk::Mountpoint,
+) -> ft_sdk::processor::Result {
+    validate_email_and_password(&email, &new_password, &new_password2)?;
+
+    let next = next.unwrap_or_else(|| "/".to_string());
+
+    let (user_id, data) = match ft_sdk::auth::provider::user_data_by_custom_attribute(
+        &mut conn,
+        email_auth::PROVIDER_ID,
+        email_auth::PASSWORD_RESET_CODE_KEY,
+        &code,
+    ) {
+        Ok(value) => value,
+        Err(ft_sdk::auth::UserDataError::NoDataFound) => {
+            return ft_sdk::processor::temporary_redirect(next)
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    if data.verified_emails.contains(&email) {
+        return ft_sdk::processor::temporary_redirect(next);
+    }
+
+    let sent_at = data
+        .get_custom(email_auth::PASSWORD_RESET_CODE_SENT_AT)
+        .expect("PASSWORD_RESET_CODE_SENT_AT should exists if the account was found");
+    let sent_at = chrono::DateTime::from_timestamp_nanos(sent_at);
+
+    if key_expired(sent_at) {
+        let reset_link = email_auth::handlers::forgot_password::generate_new_reset_key(
+            data.clone(),
+            &user_id,
+            &email,
+            spr,
+            &host,
+            &mountpoint,
+            &mut conn,
+        )?;
+
+        let name = data.name.unwrap_or_else(|| email.clone());
+
+        email_auth::handlers::forgot_password::send_reset_password_email(
+            &mut conn,
+            &email,
+            &name,
+            &reset_link,
+        )?;
+
+        return Err(ft_sdk::single_error(
+            "code",
+            "Confirmation code expired. A new link has been sent to your email address.",
+        )
+        .into());
+    }
+
+    let data = {
+        let mut data = data;
+
+        data.custom
+            .as_object_mut()
+            .expect("custom is a json object")
+            .insert(
+                "hashed_password".to_string(),
+                serde_json::Value::String(email_auth::handlers::create_account::hashed_password(
+                    &new_password,
+                )),
+            );
+
+        data.custom
+            .as_object_mut()
+            .expect("custom is a json object")
+            .remove(email_auth::PASSWORD_RESET_CODE_KEY);
+
+        data
+    };
+
+    ft_sdk::auth::provider::update_user(&mut conn, email_auth::PROVIDER_ID, &user_id, data, false)?;
+    ft_sdk::processor::temporary_redirect(next)
+}
+
+/// check if it has been 2 days since the code was sent. The threshold can be
+/// configured using RESET_PASSWORD_EXPIRE_DAYS env variable
+fn key_expired(sent_at: chrono::DateTime<chrono::Utc>) -> bool {
+    let expiry_limit_in_days: u64 = ft_sdk::env::var("RESET_PASSWORD_EXPIRE_DAYS".to_string())
+        .map(|v| {
+            v.parse()
+                .expect("EMAIL_CONFIRMATION_EXPIRE_DAYS should be a number")
+        })
+        .unwrap_or(2);
+
+    sent_at
+        .checked_add_days(chrono::Days::new(expiry_limit_in_days))
+        .unwrap()
+        <= ft_sdk::env::now()
+}
+
+fn validate_email_and_password(
+    email: &str,
+    new_password: &str,
+    new_password2: &str,
+) -> Result<(), ft_sdk::Error> {
+    if !validator::ValidateEmail::validate_email(&email) {
+        return Err(ft_sdk::single_error("email", "Invalid email format.").into());
+    }
+
+    if new_password != new_password2 {
+        return Err(ft_sdk::single_error(
+            "new-password2".to_string(),
+            "Password and Confirm password field do not match.".to_string(),
+        )
+        .into());
+    }
+
+    if let Some(message) = email_auth::handlers::create_account::is_strong_password(&new_password) {
+        return Err(ft_sdk::single_error("new-password".to_string(), message).into());
+    }
+
+    Ok(())
+}

--- a/email-auth-provider/src/handlers/set_password.rs
+++ b/email-auth-provider/src/handlers/set_password.rs
@@ -1,4 +1,4 @@
-#[ft_sdk::processor]
+#[ft_sdk::form]
 pub fn set_password(
     mut conn: ft_sdk::Connection,
     ft_sdk::Required(new_password): ft_sdk::Required<"new-password">,
@@ -8,7 +8,7 @@ pub fn set_password(
     ft_sdk::Query(email): ft_sdk::Query<"email">,
     ft_sdk::Query(next): ft_sdk::Query<"next", Option<String>>,
     host: ft_sdk::Host,
-) -> ft_sdk::processor::Result {
+) -> ft_sdk::form::Result {
     validate_email_and_password(&email, &new_password, &new_password2)?;
 
     let next = next.unwrap_or_else(|| "/".to_string());
@@ -20,9 +20,7 @@ pub fn set_password(
         &code,
     ) {
         Ok(value) => value,
-        Err(ft_sdk::auth::UserDataError::NoDataFound) => {
-            return ft_sdk::processor::temporary_redirect(next)
-        }
+        Err(ft_sdk::auth::UserDataError::NoDataFound) => return ft_sdk::form::redirect(next),
         Err(e) => return Err(e.into()),
     };
 
@@ -79,7 +77,7 @@ pub fn set_password(
     };
 
     ft_sdk::auth::provider::update_user(&mut conn, email_auth::PROVIDER_ID, &user_id, data, false)?;
-    ft_sdk::processor::temporary_redirect(next)
+    ft_sdk::form::redirect(next)
 }
 
 /// check if it has been 2 days since the code was sent. The threshold can be

--- a/email-auth-provider/src/handlers/set_password.rs
+++ b/email-auth-provider/src/handlers/set_password.rs
@@ -26,10 +26,6 @@ pub fn set_password(
         Err(e) => return Err(e.into()),
     };
 
-    if data.verified_emails.contains(&email) {
-        return ft_sdk::processor::temporary_redirect(next);
-    }
-
     let sent_at = data
         .get_custom(email_auth::PASSWORD_RESET_CODE_SENT_AT)
         .expect("PASSWORD_RESET_CODE_SENT_AT should exists if the account was found");

--- a/email-auth-provider/src/handlers/set_password.rs
+++ b/email-auth-provider/src/handlers/set_password.rs
@@ -8,7 +8,6 @@ pub fn set_password(
     ft_sdk::Query(email): ft_sdk::Query<"email">,
     ft_sdk::Query(next): ft_sdk::Query<"next", Option<String>>,
     host: ft_sdk::Host,
-    mountpoint: ft_sdk::Mountpoint,
 ) -> ft_sdk::processor::Result {
     validate_email_and_password(&email, &new_password, &new_password2)?;
 
@@ -43,7 +42,6 @@ pub fn set_password(
             &email,
             spr,
             &host,
-            &mountpoint,
             &mut conn,
         )?;
 

--- a/email-auth-provider/src/handlers/utils.rs
+++ b/email-auth-provider/src/handlers/utils.rs
@@ -1,0 +1,30 @@
+pub(crate) fn user_data_from_email_or_username<S: AsRef<str>>(
+    conn: &mut ft_sdk::Connection,
+    email_or_username: S,
+) -> Result<(ft_sdk::UserId, ft_sdk::auth::ProviderData), ft_sdk::auth::UserDataError> {
+    let email_or_username = email_or_username.as_ref();
+
+    if email_or_username.contains('@') {
+        match ft_sdk::auth::provider::user_data_by_email(
+            conn,
+            email_auth::PROVIDER_ID,
+            email_or_username,
+        ) {
+            Ok(v) => return Ok(v),
+            Err(ft_sdk::auth::UserDataError::NoDataFound) => {
+                return ft_sdk::auth::provider::user_data_by_verified_email(
+                    conn,
+                    email_auth::PROVIDER_ID,
+                    email_or_username,
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    } else {
+        return ft_sdk::auth::provider::user_data_by_identity(
+            conn,
+            email_auth::PROVIDER_ID,
+            email_or_username,
+        );
+    };
+}

--- a/email-auth-provider/src/lib.rs
+++ b/email-auth-provider/src/lib.rs
@@ -3,7 +3,11 @@ extern crate self as email_auth;
 mod handlers;
 mod urls;
 
+pub(crate) use handlers::utils;
+
 pub const PROVIDER_ID: &str = "email";
 pub const SUBSCRIPTION_PROVIDER_ID: &str = "subscription";
 pub const EMAIL_CONF_CODE_KEY: &str = "email_confirmation_code";
+pub const PASSWORD_RESET_CODE_KEY: &str = "password_reset_code";
+pub const PASSWORD_RESET_CODE_SENT_AT: &str = "password_reset_code_sent_at";
 pub const EMAIL_CONF_SENT_AT: &str = "email_conf_sent_at";


### PR DESCRIPTION
Add support for password reset by implementing some handlers. Specifically:

- `/forgot-password/`: Request a password reset email.
- `/set-password/`: Set a new password for a given user. Links in emails sent from `/forgot-password/` rely on this handler.

Also contains some minor refactoring.